### PR TITLE
[BEAM-3531]  Fixed NPE when running the Nexmark DEFAULT testing suite

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -1157,7 +1157,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
   private NexmarkQuery getNexmarkQuery() {
     List<NexmarkQuery> queries = createQueries();
 
-    if (options.getQuery() >= queries.size()) {
+    if (configuration.query >= queries.size()) {
       throw new UnsupportedOperationException(
           "Query " + options.getQuery()
           + " is not implemented yet");


### PR DESCRIPTION
Get the "query" option from configuration not options which is from command line only. But when running the test by test suite(like --suite=DEFAULT), there is no query option from the command line. Thus we should always get the "query" from the "configuration" which covers both the command line and test suite.